### PR TITLE
Fix `:num-calls` option in `c/verify`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# clojure
+.cpcache/
+.nrepl-port
+
+# IDE config
+.idea/
+*.iml

--- a/src/griffin/test/contract.cljc
+++ b/src/griffin/test/contract.cljc
@@ -308,7 +308,7 @@
   [model impl-f & {:keys [num-calls]
                    :or {num-calls 10}
                    :as _opts}]
-  (prop/for-all [calls (gen-calls model (p/initial-state model) num-calls)]
+  (prop/for-all [calls (gen-calls model (p/initial-state model) :max-length num-calls)]
                 (let [impl (impl-f)
                       executed-calls (atom [])]
                   (try


### PR DESCRIPTION
Currently the `:num-calls` option in `c/verify` does nothing, because it's being passed to `gen-calls` as a number instead of an options map or kw-args

This PR first adds a failing test reproducing the issue, then fixes it. Since there wasn't a .gitignore yet, I started one with just the files I needed to ignore.

I'm not sure if the way I wrote the test is ideal, as `with-redefs` never feels great, so I'm open to suggestions.