### PR TITLE
change ns g.t.c.mock to g.t.c.mock-protocol

### DIFF
--- a/src/griffin/test/contract.cljc
+++ b/src/griffin/test/contract.cljc
@@ -115,6 +115,9 @@
         (swap! s f)
         this))))
 
+(defn var->sym [v]
+  (symbol (str (-> v meta :ns ns-name)) (str (-> v meta :name))))
+
 (defn mock
   "Given a model, return an instance of the protocol.
 
@@ -131,7 +134,7 @@
          p/protocols
          (mapcat :method-builders)
          (map (fn [[v _f]]
-                (let [s (symbol (str (.ns v)) (str (.sym v)))
+                (let [s (var->sym v)
                       method (p/get-method model v)]
                   (assert method)
                   [s (fn [_ & args]
@@ -349,7 +352,7 @@
             p/protocols
             (mapcat :method-builders)
             (map (fn [[v _f]]
-                   (let [s (symbol (str (.ns v)) (str (.sym v)))
+                   (let [s (var->sym v)
                          method (p/get-method model v)]
                      [s (fn [_this & args]
                           (let [*ret (atom nil)]

--- a/src/griffin/test/contract.cljc
+++ b/src/griffin/test/contract.cljc
@@ -5,7 +5,7 @@
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.rose-tree :as rose]
-            [griffin.test.contract.mock :as mock]
+            [griffin.test.contract.mock-protocol :as mock-protocol]
             [griffin.test.contract.protocol :as p]))
 
 (defn deep-merge
@@ -93,12 +93,12 @@
      "Returns an implementation of MockState that simulates state living longer than the lifetime of a single mock instance (e.g a database client & its backing database).  Pass in a ref that you use to manage the lifetime of mock state"
      [r]
      (validate! ref? r)
-     (reify mock/State
-       (mock/init-state [this i]
+     (reify mock-protocol/State
+       (mock-protocol/init-state [this i]
          (dosync
           (alter r deep-merge i))
          this)
-       (mock/swap-state [this f]
+       (mock-protocol/swap-state [this f]
          (dosync
           (alter r f))
          this))))
@@ -107,11 +107,11 @@
   "An implementation of MockState that does not persist"
   []
   (let [s (atom nil)]
-    (reify mock/State
-      (mock/init-state [this i]
+    (reify mock-protocol/State
+      (mock-protocol/init-state [this i]
         (reset! s i)
         this)
-      (mock/swap-state [this f]
+      (mock-protocol/swap-state [this f]
         (swap! s f)
         this))))
 
@@ -119,13 +119,13 @@
   "Given a model, return an instance of the protocol.
 
   Options:
-  mock-state: an instance of `mock/State`, used to control the lifetime of mock state. See `c/ref-state`
+  mock-state: an instance of `mock-protocol/State`, used to control the lifetime of mock state. See `c/ref-state`
   seed: an RNG seed to pass to `gen/generate`, for deterministic results inside a generative test
   "
   [model & {:keys [mock-state seed]
             :or {mock-state (ephemeral-state)}}]
   (assert (every? :extend-via-metadata (p/protocols model)) ":extend-via-metadata must be set on the protocol")
-  (mock/init-state mock-state (p/initial-state model))
+  (mock-protocol/init-state mock-state (p/initial-state model))
   (with-meta {}
     (->> model
          p/protocols
@@ -137,7 +137,7 @@
                   [s (fn [_ & args]
                        ;; TODO should this throw if `precondition` is violated?
                        (let [*ret-value (atom nil)]
-                         (mock/swap-state mock-state (fn [current-state]
+                         (mock-protocol/swap-state mock-state (fn [current-state]
                                                        (let [ret (p/return method current-state args)
                                                              _ (assert ret)
                                                              ret-spec (p/spec ret)
@@ -342,7 +342,7 @@
                  :or {return :implementation
                       mock-state (ephemeral-state)}}]
   (validate! ::model model)
-  (let [state (mock/init-state mock-state (p/initial-state model))]
+  (let [state (mock-protocol/init-state mock-state (p/initial-state model))]
     (with-meta {}
       (merge
        (->> model
@@ -353,7 +353,7 @@
                          method (p/get-method model v)]
                      [s (fn [_this & args]
                           (let [*ret (atom nil)]
-                            (mock/swap-state state (fn [current-state]
+                            (mock-protocol/swap-state state (fn [current-state]
                                                      (let [ret (p/return method current-state args)]
                                                        (reset! *ret ret)
                                                        (p/next-state ret))))

--- a/src/griffin/test/contract/mock_protocol.cljc
+++ b/src/griffin/test/contract/mock_protocol.cljc
@@ -1,4 +1,4 @@
-(ns griffin.test.contract.mock)
+(ns griffin.test.contract.mock-protocol)
 
 (defprotocol State
   (init-state [this i]

--- a/test/griffin/test/contract_test.clj
+++ b/test/griffin/test/contract_test.clj
@@ -186,5 +186,5 @@
   (deftest broken-model-test
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
-         #":args must return a generator for"
+         #":args must return a generator for*"
          (tc/quick-check 1 (c/test-model broken-model))))))


### PR DESCRIPTION
This fixes a bug, which occurs in CLJS, where mock fn overrides the g.t.c.mock namespace completely.
See:
https://clojurians.slack.com/archives/C03S1L9DN/p1732105416688439?thread_ts=1732100469.195189&cid=C03S1L9DN